### PR TITLE
scraper: improve assert error messages for backtrace

### DIFF
--- a/kuroneko/scraper.py
+++ b/kuroneko/scraper.py
@@ -123,8 +123,12 @@ def split_version_ranges(packages: typing.Iterable[atom]
                 except StopIteration:
                     break
 
-                assert p1.key == p2.key
-                assert p1.fullver != p2.fullver
+                assert p1.key == p2.key,
+                  (f'expected equal keys: {p1} == {p2}')
+                assert p1.fullver != p2.fullver,
+                  (f'expected not_equal fullver: '
+                   f'{p1.fullver} != {p2.fullver}, '
+                   f'p1 = {p1}, p2 = {p2}')
                 v1 = VER_SPLIT_RE.split(p1.fullver)
                 v2 = VER_SPLIT_RE.split(p2.fullver)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.10/site-packages/kuroneko/scraper.py", line 220, in <module>
    raise SystemExit(main())
  File "/usr/lib/python3.10/site-packages/kuroneko/scraper.py", line 193, in main
    packages = sorted(split_version_ranges(
  File "/usr/lib/python3.10/site-packages/kuroneko/scraper.py", line 127, in split_version_ranges
    assert p1.fullver != p2.fullver
AssertionError
```

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>